### PR TITLE
Fix: Admin-dashboard y Admin-assignTicket

### DIFF
--- a/app/admin/assign-ticket/page.tsx
+++ b/app/admin/assign-ticket/page.tsx
@@ -61,7 +61,7 @@ type User = {
 };
 
 const fetchTickets = async (): Promise<Ticket[]> => {
-  const response = await fetch("/api/tickets");
+  const response = await fetch("/api/tickets?unassigned=true");
   if (!response.ok) {
     throw new Error("Failed to fetch tickets");
   }

--- a/app/api/dashboard-routes/route.ts
+++ b/app/api/dashboard-routes/route.ts
@@ -186,7 +186,7 @@ async function getTechnicianPerformance() {
         },
       });
       return {
-        name: user?.name || 'Unknown',
+        name: user?.firstName +" "+ user?.lastName[0] || 'Unknown',
         completed: completedTickets,
         pending: pendingTickets,
       };
@@ -232,7 +232,7 @@ async function getCompanySummary() {
         },
       });
       return {
-        name: client?.name || 'Unknown',
+        name: client?.firstName +" "+ client?.lastName[0] || 'Unknown',
         completed: completedTickets,
         pending: pendingTickets,
       };

--- a/app/api/tickets/route.ts
+++ b/app/api/tickets/route.ts
@@ -104,11 +104,18 @@ export async function GET(request: Request) {
       headers: { "Content-Type": "application/json" },
     });
   }
+  
 
   try {
     const { searchParams } = new URL(request.url);
     const whereCondition: Prisma.TicketWhereInput =
       buildWhereCondition(searchParams);
+
+       // Si se especifica unassigned=true, solo devolver tickets sin asignar
+    const unassigned = searchParams.get("unassigned");
+    if (unassigned === "true") {
+      whereCondition.userId = null;
+    }
 
     const tickets = await prisma.ticket.findMany({
       where: whereCondition,


### PR DESCRIPTION
En el dashboard algunas tablas no reconocian los nombres tanto de usuarios como de clientes
el la seccion de asignar tickets, aparecian todos los tickets, sin importar si ya tenian un user asignado